### PR TITLE
fix to allow running under ECS using IAM task role

### DIFF
--- a/configs/entrypoint.sh
+++ b/configs/entrypoint.sh
@@ -59,16 +59,15 @@ then
 aws_secret_access_key = $AWS_SECRET" >> ${AWS_FOLDER}/config
     fix_perm
 # if the key and secret are not mounted as secrets
-elif test_iam
-then
+else
     echo "key and secret not available in ~/.aws/"
     if aws ecr get-authorization-token | grep expiresAt
     then
         echo "iam role configured to allow ecr access"
+    else
+        echo "key and secret not mounted as secret, declared as variables or available from iam role"
+        exit 1
     fi
-else
-    echo "key and secret not mounted as secret, declared as variables or available from iam role"
-    exit 1
 fi
 
 # update the auth token


### PR DESCRIPTION
ECS tasks get IAM credentials from a different endpoint than EC2 instances so rather than test the endpoint used by EC2 just test if we can get the token through AWS cli